### PR TITLE
Add permissions service unit test

### DIFF
--- a/9-complete-with-all-defence-layers/src/test/java/defence/in/depth/unit/domain/service/PermissionServiceTest.java
+++ b/9-complete-with-all-defence-layers/src/test/java/defence/in/depth/unit/domain/service/PermissionServiceTest.java
@@ -1,0 +1,83 @@
+package defence.in.depth.unit.domain.service;
+
+import defence.in.depth.domain.model.ProductMarketId;
+import defence.in.depth.domain.service.PermissionService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+public class PermissionServiceTest {
+    private Authentication authentication;
+
+    @BeforeEach
+    public void setupMocks() {
+        authentication = Mockito.mock(Authentication.class);
+        SecurityContextHolder.setContext(new SecurityContext() {
+            @Override
+            public Authentication getAuthentication() {
+                return authentication;
+            }
+
+            @Override
+            public void setAuthentication(Authentication authentication) {
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    @Test
+    void hasPermissionsToSE() {
+        PermissionService permissionService = new PermissionService();
+
+        Assertions.assertTrue(permissionService.hasPermissionToMarket(ProductMarketId.SE));
+    }
+
+    @Test
+    void hasNoPermissionsToNO() {
+        PermissionService permissionService = new PermissionService();
+
+        Assertions.assertFalse(permissionService.hasPermissionToMarket(ProductMarketId.NO));
+    }
+
+    @Test
+    void hasNoPermissionsToFI() {
+        PermissionService permissionService = new PermissionService();
+
+        Assertions.assertFalse(permissionService.hasPermissionToMarket(ProductMarketId.FI));
+    }
+
+    @Test
+    void hasOnlyWrite_DeniesRead() {
+        Mockito.when(authentication.getAuthorities()).thenAnswer(invocationOnMock -> List.of(
+                new SimpleGrantedAuthority(PermissionService.WRITE_PRODUCTS_SCOPE)
+        ));
+
+        PermissionService permissionService = new PermissionService();
+        boolean read = permissionService.canReadProducts();
+        boolean write = permissionService.canWriteProducts();
+
+        Assertions.assertTrue(write);
+        Assertions.assertFalse(read);
+    }
+
+    @Test
+    void hasOnlyRead_DeniesWrite() {
+        Mockito.when(authentication.getAuthorities()).thenAnswer(invocationOnMock -> List.of(
+                new SimpleGrantedAuthority(PermissionService.READ_PRODUCTS_SCOPE)
+        ));
+
+        PermissionService permissionService = new PermissionService();
+        boolean read = permissionService.canReadProducts();
+        boolean write = permissionService.canWriteProducts();
+
+        Assertions.assertFalse(write);
+        Assertions.assertTrue(read);
+    }
+}


### PR DESCRIPTION
This PR adds a unit test for the permissions service which was missing earlier. 
It is mentioned in [Secure APIs by Design, Security Tests and Verification](https://securityblog.omegapoint.se/en/secure-apis-by-design#security-tests-and-verification), step 3 that the permissions service is tested, however that is missing for the Java implementation. 

In the [C# implementation](https://github.com/Omegapoint/defence-in-depth/blob/main/rest-api/9-complete-with-all-defence-layers/Domain/Services/HttpContextPermissionService.cs), the PermissionsService is scoped to each request and therefore works a bit different.