### PR TITLE
Update keycloak container

### DIFF
--- a/2-token-validation/src/main/resources/application.yml
+++ b/2-token-validation/src/main/resources/application.yml
@@ -11,5 +11,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
 

--- a/3-token-transformation/src/main/resources/application.yml
+++ b/3-token-transformation/src/main/resources/application.yml
@@ -11,5 +11,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
 

--- a/4-input-data-validation/src/main/resources/application.yml
+++ b/4-input-data-validation/src/main/resources/application.yml
@@ -11,5 +11,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
 

--- a/5-operation-validation/src/main/resources/application.yml
+++ b/5-operation-validation/src/main/resources/application.yml
@@ -11,5 +11,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
 

--- a/6-data-access-validation/src/main/resources/application.yml
+++ b/6-data-access-validation/src/main/resources/application.yml
@@ -11,5 +11,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
 

--- a/7-secure-by-design/src/main/resources/application.yml
+++ b/7-secure-by-design/src/main/resources/application.yml
@@ -11,5 +11,5 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
 

--- a/9-complete-with-all-defence-layers/src/main/resources/application.yml
+++ b/9-complete-with-all-defence-layers/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8180/auth/realms/defence-in-depth
+          issuer-uri: http://localhost:8180/realms/defence-in-depth
   config:
     import:
       'optional:aws-secretsmanager:defence-in-depth'

--- a/9-complete-with-all-defence-layers/src/test/resources/application-system.properties
+++ b/9-complete-with-all-defence-layers/src/test/resources/application-system.properties
@@ -1,4 +1,4 @@
 baseUrl=https://localhost:8443
-tokenUrl=http://localhost:8180/auth/realms/defence-in-depth/protocol/openid-connect/token
+tokenUrl=http://localhost:8180/realms/defence-in-depth/protocol/openid-connect/token
 validClient.clientId=m2m
 validClient.clientSecret=secret

--- a/API.http
+++ b/API.http
@@ -2,7 +2,7 @@
 GET https://localhost:8443/api/products/se1
 
 ### Fetch access-token from token service
-POST http://localhost:8180/auth/realms/defence-in-depth/protocol/openid-connect/token
+POST http://localhost:8180/realms/defence-in-depth/protocol/openid-connect/token
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=client_credentials&client_id=m2m&client_secret=secret&scope=products.read

--- a/token-service/docker-compose.yml
+++ b/token-service/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
       - 8180:8080
-    command: start-dev --import-realm --http-relative-path /auth
+    command: start-dev --import-realm

--- a/token-service/docker-compose.yml
+++ b/token-service/docker-compose.yml
@@ -1,12 +1,11 @@
 services:
   keycloak:
-    image: jboss/keycloak
+    image: quay.io/keycloak/keycloak:21.1
     volumes:
-      - ./keycloak:/opt/jboss/keycloak/imports
+      - ./keycloak:/opt/keycloak/data/import
     environment:
-      KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: admin
-      KEYCLOAK_IMPORT: /opt/jboss/keycloak/imports/realm-export.json
-      DB_VENDOR: h2
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
       - 8180:8080
+    command: start-dev --import-realm --http-relative-path /auth


### PR DESCRIPTION
Keycloak has moved from their Wildfly distribution to a Quarkus-based application. See [migration notes](https://www.keycloak.org/migration/migrating-to-quarkus). 
The Wildfly-based distribution (jboss-distributed) also only exists for amd64, where developer machines today see quite a mix of amd64 and arm64. 
This works as a drop-in replacement, using the official container image ([docs](https://www.keycloak.org/server/containers#_importing_a_realm_on_startup)), version-pinned to mitigate image updates but not updating environment variables.
With the upgrade, the HTTP path prefix `/auth` has also been removed, which is reflected in the update application configurations accordingly.