### PR TITLE
Add audit service, with implementation to log only. Updated tests to verify auditing.

### DIFF
--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/model/DomainEvent.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/model/DomainEvent.java
@@ -1,0 +1,5 @@
+package defence.in.depth.domain.model;
+
+public enum DomainEvent {
+    NO_ACCESS_TO_OPERATION, NO_ACCESS_TO_DATA, PRODUCT_READ
+}

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/AuditService.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/AuditService.java
@@ -1,0 +1,7 @@
+package defence.in.depth.domain.service;
+
+import defence.in.depth.domain.model.DomainEvent;
+
+public interface AuditService {
+    void log(DomainEvent event, Object payload);
+}

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/LoggingAuditService.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/LoggingAuditService.java
@@ -1,0 +1,23 @@
+package defence.in.depth.domain.service;
+
+import defence.in.depth.domain.model.DomainEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoggingAuditService implements AuditService {
+    private final Logger logger = LoggerFactory.getLogger(LoggingAuditService.class);
+
+    private final PermissionService permissionService;
+
+    public LoggingAuditService(PermissionService permissionService) {
+        this.permissionService = permissionService;
+    }
+
+    @Override
+    public void log(DomainEvent event, Object payload) {
+        String source = permissionService.getUserName();
+        logger.info("{} occurred by {}. Extra data: {}", event, source, payload);
+    }
+}

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/PermissionService.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/PermissionService.java
@@ -22,6 +22,10 @@ public class PermissionService {
         return getMarketForAuthenticatedUser().equals(productMarketId);
     }
 
+    public String getUserName() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
+    }
+
     private ProductMarketId getMarketForAuthenticatedUser() {
         // This is typically a service call or database query, based on identity
         return ProductMarketId.SE;

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/ProductsService.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/domain/service/ProductsService.java
@@ -5,6 +5,7 @@ import defence.in.depth.domain.exceptions.ProductMarketMismatchException;
 import defence.in.depth.domain.exceptions.ProductNotFoundException;
 import defence.in.depth.domain.exceptions.ReadProductNotAllowedException;
 import defence.in.depth.domain.mapper.ProductMapper;
+import defence.in.depth.domain.model.DomainEvent;
 import defence.in.depth.domain.model.Product;
 import defence.in.depth.domain.model.ProductId;
 import org.springframework.stereotype.Service;
@@ -15,13 +16,17 @@ public class ProductsService {
     private final ProductsRepository productsRepository;
     private final PermissionService permissionService;
 
-    public ProductsService(ProductsRepository productsRepository, PermissionService permissionService) {
+    private final AuditService auditService;
+
+    public ProductsService(ProductsRepository productsRepository, PermissionService permissionService, AuditService auditService) {
         this.productsRepository = productsRepository;
         this.permissionService = permissionService;
+        this.auditService = auditService;
     }
 
     public Product getById(ProductId productId) {
         if (!permissionService.canReadProducts()) {
+            auditService.log(DomainEvent.NO_ACCESS_TO_OPERATION, productId);
             throw new ReadProductNotAllowedException("User not allowed to read product");
         }
 
@@ -31,8 +36,11 @@ public class ProductsService {
             .orElseThrow(() -> new ProductNotFoundException("Product not found"));
 
         if (!permissionService.hasPermissionToMarket(product.getMarket())) {
+            auditService.log(DomainEvent.NO_ACCESS_TO_DATA, productId);
             throw new ProductMarketMismatchException("User market does not match product market");
         }
+
+        auditService.log(DomainEvent.PRODUCT_READ, productId);
         return product;
     }
 }


### PR DESCRIPTION
The java implementation is currently missing the audit capability, as specified in [Secure by Design](https://securityblog.omegapoint.se/en/secure-apis-by-design#secure-by-design). 
This PR aims to add such functionality, complete with tests for the products service to create an audit trace for potentially illicit users. 
The [C# implementation](https://github.com/Omegapoint/defence-in-depth/blob/main/rest-api/9-complete-with-all-defence-layers/Domain/Services/ProductService.cs) can be used as reference.