### PR TITLE
Dependency update

### DIFF
--- a/1-request-validation/pom.xml
+++ b/1-request-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>request-validation</artifactId>
     <name>1-request-validation</name>

--- a/1-request-validation/pom.xml
+++ b/1-request-validation/pom.xml
@@ -3,19 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>request-validation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>1-request-validation</name>
     <description>Validate that the request is correct</description>
-    <properties>
-        <java.version>17</java.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/2-token-validation/pom.xml
+++ b/2-token-validation/pom.xml
@@ -3,19 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>token-validation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>2-token-validation</name>
     <description>Validate that the access token is correct</description>
-    <properties>
-        <java.version>17</java.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/2-token-validation/pom.xml
+++ b/2-token-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>token-validation</artifactId>
     <name>2-token-validation</name>

--- a/2-token-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
+++ b/2-token-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
@@ -4,11 +4,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -16,18 +16,19 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
 
 @Configuration
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(authorize -> authorize
                 .anyRequest().authenticated()
             )
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+        return http.build();
     }
 
     @Bean

--- a/3-token-transformation/pom.xml
+++ b/3-token-transformation/pom.xml
@@ -3,19 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>token-transformation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>3-token-transformation</name>
     <description>Transform the access token into a permissions model</description>
-    <properties>
-        <java.version>17</java.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/3-token-transformation/pom.xml
+++ b/3-token-transformation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>token-transformation</artifactId>
     <name>3-token-transformation</name>

--- a/3-token-transformation/src/main/java/defence/in/depth/SecurityConfiguration.java
+++ b/3-token-transformation/src/main/java/defence/in/depth/SecurityConfiguration.java
@@ -4,11 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -16,18 +15,19 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
 
 @Configuration
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(jwt -> jwt.jwt().jwtAuthenticationConverter(new CustomJwtAuthenticationConverter()));
+        return http.build();
     }
 
     @Bean

--- a/4-input-data-validation/pom.xml
+++ b/4-input-data-validation/pom.xml
@@ -3,20 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>input-data-validation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>4-input-data-validation</name>
     <description>Validate that the data in the request is correct</description>
-    <properties>
-        <java.version>17</java.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/4-input-data-validation/pom.xml
+++ b/4-input-data-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>input-data-validation</artifactId>
     <name>4-input-data-validation</name>

--- a/4-input-data-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
+++ b/4-input-data-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
@@ -4,10 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -15,18 +15,19 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
 
 @Configuration
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(jwt -> jwt.jwt().jwtAuthenticationConverter(new CustomJwtAuthenticationConverter()));
+        return http.build();
     }
 
     @Bean

--- a/5-operation-validation/pom.xml
+++ b/5-operation-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>operation-validation</artifactId>
     <name>5-operation-validation</name>

--- a/5-operation-validation/pom.xml
+++ b/5-operation-validation/pom.xml
@@ -3,20 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>operation-validation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>5-operation-validation</name>
     <description>Validate the permission to execute the operation</description>
-    <properties>
-        <java.version>17</java.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/5-operation-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
+++ b/5-operation-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
@@ -4,10 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -15,18 +15,19 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
 
 @Configuration
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(jwt -> jwt.jwt().jwtAuthenticationConverter(new CustomJwtAuthenticationConverter()));
+        return http.build();
     }
 
     @Bean

--- a/6-data-access-validation/pom.xml
+++ b/6-data-access-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>data-access-validation</artifactId>
     <name>6-data-access-validation</name>

--- a/6-data-access-validation/pom.xml
+++ b/6-data-access-validation/pom.xml
@@ -3,20 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>data-access-validation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>6-data-access-validation</name>
     <description>Validate the permission to query or change data</description>
-    <properties>
-        <java.version>17</java.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/6-data-access-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
+++ b/6-data-access-validation/src/main/java/defence/in/depth/SecurityConfiguration.java
@@ -4,10 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -15,18 +15,19 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
 
 @Configuration
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorize -> authorize
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(jwt -> jwt.jwt().jwtAuthenticationConverter(new CustomJwtAuthenticationConverter()));
+        return http.build();
     }
 
     @Bean

--- a/7-secure-by-design/pom.xml
+++ b/7-secure-by-design/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>secure-by-design</artifactId>
     <name>7-secure-by-design</name>

--- a/7-secure-by-design/pom.xml
+++ b/7-secure-by-design/pom.xml
@@ -3,20 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>secure-by-design</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>7-secure-by-design</name>
     <description>Secure by design with a Core Business Domain</description>
-    <properties>
-        <java.version>17</java.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/7-secure-by-design/src/main/java/defence/in/depth/security/SecurityConfiguration.java
+++ b/7-secure-by-design/src/main/java/defence/in/depth/security/SecurityConfiguration.java
@@ -4,11 +4,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -18,19 +18,20 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
 
 @Configuration
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration  {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
             .authorizeHttpRequests(authorize -> authorize
                 .anyRequest().authenticated()
             )
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+        return http.build();
     }
 
     @Bean

--- a/8-secrets/pom.xml
+++ b/8-secrets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>secrets</artifactId>
     <name>8-secrets</name>

--- a/8-secrets/pom.xml
+++ b/8-secrets/pom.xml
@@ -3,20 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>secrets</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>8-secrets</name>
     <description>Using Secrets Manager for secrets</description>
-    <properties>
-        <java.version>17</java.version>
-        <spring-cloud-aws.version>2.4.1</spring-cloud-aws.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/9-complete-with-all-defence-layers/pom.xml
+++ b/9-complete-with-all-defence-layers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>defence.in.depth</groupId>
         <artifactId>root</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>complete-with-all-defence-layers</artifactId>
     <name>9-complete-with-all-defence-layers</name>

--- a/9-complete-with-all-defence-layers/pom.xml
+++ b/9-complete-with-all-defence-layers/pom.xml
@@ -3,21 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <groupId>defence.in.depth</groupId>
+        <artifactId>root</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
-    <groupId>defence.in.depth</groupId>
     <artifactId>complete-with-all-defence-layers</artifactId>
-    <version>1.0.0</version>
     <name>9-complete-with-all-defence-layers</name>
     <description>Complete with all defence layers</description>
-    <properties>
-        <java.version>17</java.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-        <spring-cloud-aws.version>2.4.1</spring-cloud-aws.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/controller/ProductsController.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/controller/ProductsController.java
@@ -24,7 +24,7 @@ public class ProductsController {
         this.productsService = productsService;
     }
 
-    // More granular control using preauthorize as a compliment to antMatchers defined in the security configuration.
+    // More granular control using preauthorize as a compliment to requestMatchers defined in the security configuration.
     // Note that the main permission check is still in the core business domain in the productsService
     @PreAuthorize("hasAuthority('" + READ_PRODUCTS_SCOPE + "')")
     @GetMapping("/{id}")

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
@@ -38,6 +38,7 @@ public class SecurityConfiguration {
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/api/products/**").hasAnyAuthority(READ_PRODUCTS_SCOPE, WRITE_PRODUCTS_SCOPE)
                 .requestMatchers("/api/health/live").permitAll()
+                .requestMatchers("/error/**").permitAll()
                 .requestMatchers("/api/health/**").authenticated()
                 .requestMatchers("/api/error/**").authenticated()
                 .requestMatchers("/**").denyAll() // Force authorization on all new endpoints

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
@@ -5,11 +5,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
 
@@ -21,14 +21,13 @@ import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 // Note that you need to set prePostEnabled to true in order to get PreAuthorize to work
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
     private String issuerUri;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         // We will add antMatchers as a first layer of defence, but also make use of more granular checks using
         // @PreAuthorize on each controller.
         // The two last steps here, antMatchers("/**").denyALl() and .anyRequest().authenticated() will force
@@ -46,6 +45,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .anyRequest().authenticated() // Force authentication on all new endpoints
             )
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+        return http.build();
     }
 
     @Bean

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -17,10 +18,8 @@ import static defence.in.depth.domain.service.PermissionService.READ_PRODUCTS_SC
 import static defence.in.depth.domain.service.PermissionService.WRITE_PRODUCTS_SCOPE;
 import static org.springframework.security.oauth2.jwt.JwtClaimNames.AUD;
 
-
-// Note that you need to set prePostEnabled to true in order to get PreAuthorize to work
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
 public class SecurityConfiguration {
 
     @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
@@ -28,20 +27,20 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // We will add antMatchers as a first layer of defence, but also make use of more granular checks using
+        // We will add requestMatchers as a first layer of defence, but also make use of more granular checks using
         // @PreAuthorize on each controller.
-        // The two last steps here, antMatchers("/**").denyALl() and .anyRequest().authenticated() will force
+        // The two last steps here, requestMatchers("/**").denyALl() and .anyRequest().authenticated() will force
         // authorization and authentication on all endpoints by default.
-        // antMatchers("/**").denyAll() will return 403 if not matched above, for example authenticated user without scopes
+        // requestMatchers("/**").denyAll() will return 403 if not matched above, for example authenticated user without scopes
         // .anyRequest().authenticated() will force authentication on all endpoints.
         // This should always be last step of the chain to force opt-out security
         http
             .authorizeHttpRequests(authorize -> authorize
-                .antMatchers("/api/products/**").hasAnyAuthority(READ_PRODUCTS_SCOPE, WRITE_PRODUCTS_SCOPE)
-                .antMatchers("/api/health/live").permitAll()
-                .antMatchers("/api/health/**").authenticated()
-                .antMatchers("/api/error/**").authenticated()
-                .antMatchers("/**").denyAll() // Force authorization on all new endpoints
+                .requestMatchers("/api/products/**").hasAnyAuthority(READ_PRODUCTS_SCOPE, WRITE_PRODUCTS_SCOPE)
+                .requestMatchers("/api/health/live").permitAll()
+                .requestMatchers("/api/health/**").authenticated()
+                .requestMatchers("/api/error/**").authenticated()
+                .requestMatchers("/**").denyAll() // Force authorization on all new endpoints
                 .anyRequest().authenticated() // Force authentication on all new endpoints
             )
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);

--- a/9-complete-with-all-defence-layers/src/test/java/defence/in/depth/system/HealthTests.java
+++ b/9-complete-with-all-defence-layers/src/test/java/defence/in/depth/system/HealthTests.java
@@ -40,7 +40,7 @@ public class HealthTests extends BaseTests {
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.body()).contains("\"version\":\"1.0.0\"");
+        assertThat(response.body()).contains("\"version\":\"1.0.0-SNAPSHOT\"");
     }
 
     @Test
@@ -53,7 +53,7 @@ public class HealthTests extends BaseTests {
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.body()).contains("\"version\":\"1.0.0\"");
+        assertThat(response.body()).contains("\"version\":\"1.0.0-SNAPSHOT\"");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <packaging>pom</packaging>
     <properties>
         <java.version>17</java.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <spring-cloud-aws.version>2.4.1</spring-cloud-aws.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.8</version>
+        <version>3.1.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
+        <version>2.7.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <java.version>17</java.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
-        <spring-cloud-aws.version>2.4.1</spring-cloud-aws.version>
+        <spring-cloud-aws.version>2.4.4</spring-cloud-aws.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>defence.in.depth</groupId>
     <artifactId>root</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>defence-in-depth</name>
     <description>Secure Rest API according to Defence In Depth</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.13</version>
+        <version>3.0.8</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
This PR updates the Java dependencies for the project, as per #5.

To simplify the process, duplicated configuration was consolidated to the root POM. 
This also ensures a consistent release version of the different modules in the project. To simplify development and hands-on use, `1.0.0-SNAPSHOT` is used, as maven does not expect release versions (non-snapshot) to be updated.

The dependency update was done according to the Spring Boot documentation, therefore 2.6 -> 2.7 -> 3.0 -> 3.1 (latest stable). 
The two main change required were:
* Migrate from WebSecurityConfigurerAdapter, [reference](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)
  * TLDR Spring security has deprecated an adapter bean in favor of another bean
* Migrate to new requestmatcher methods [reference](https://docs.spring.io/spring-security/reference/5.8/migration/servlet/config.html#use-new-requestmatchers)
  * TLDR Spring security has consolidated request matching methods, with same interface and functionality but under the same name for multiple functions
  * Side-effect: `.requestMatchers("/**").denyAll()` also denies `/error` mappings for all users. This affects unhandled exceptions (such as [ErrorController](https://github.com/Omegapoint/defence-in-depth-java/blob/main/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/controller/ErrorController.java)) and returns a 403 instead of 500, since we are not allowed to view the error page/mapping. 
    * Solution: Permit all users to view `/error` mappings. **REQUIRES REVIEW**.

Also, the spring cloud aws version is updated to the latest one before the major update (only patch update as per semver). 
The project passes all tests after the changes. 