### PR TITLE
Deny unauthenticated users to see the error page

### DIFF
--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/controller/ErrorController.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/controller/ErrorController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ErrorController {
 
     @PutMapping("")
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity throwException() {
         throw new NotImplementedException("Not implemented on purpose");
     }

--- a/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
+++ b/9-complete-with-all-defence-layers/src/main/java/defence/in/depth/security/SecurityConfiguration.java
@@ -34,11 +34,13 @@ public class SecurityConfiguration {
         // requestMatchers("/**").denyAll() will return 403 if not matched above, for example authenticated user without scopes
         // .anyRequest().authenticated() will force authentication on all endpoints.
         // This should always be last step of the chain to force opt-out security
+        // Note that the /error matcher is required to return error responses for authenticated requests.
+        // See more: https://spring.io/blog/2013/11/01/exception-handling-in-spring-mvc
         http
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers("/api/products/**").hasAnyAuthority(READ_PRODUCTS_SCOPE, WRITE_PRODUCTS_SCOPE)
                 .requestMatchers("/api/health/live").permitAll()
-                .requestMatchers("/error/**").permitAll()
+                .requestMatchers("/error").authenticated()
                 .requestMatchers("/api/health/**").authenticated()
                 .requestMatchers("/api/error/**").authenticated()
                 .requestMatchers("/**").denyAll() // Force authorization on all new endpoints

--- a/9-complete-with-all-defence-layers/src/test/java/defence/in/depth/system/ErrorTests.java
+++ b/9-complete-with-all-defence-layers/src/test/java/defence/in/depth/system/ErrorTests.java
@@ -1,22 +1,15 @@
 package defence.in.depth.system;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
 import java.net.URI;
-import java.time.Instant;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.Set;
+import java.time.Instant;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -50,6 +43,19 @@ public class ErrorTests extends BaseTests {
                 .satisfies(field -> assertThat(Instant.parse((String) field)).isBefore(Instant.now()));
     }
 
+    @Test
+    public void throwWithNoToken_ShouldReturn401() throws IOException, InterruptedException {
+        HttpClient httpClient = HttpClient.newHttpClient();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .PUT(HttpRequest.BodyPublishers.noBody())
+                .uri(URI.create(getBaseUrl() + "/api/error"))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
 
     private record ErrorDTO(String status, String error, String path, String timestamp, String derp) {
         private ErrorDTO(String status, String error, String path) {


### PR DESCRIPTION
This PR does two things:
* switches the `@PreAuthorize` statement to `isAuthenticated` instead of `permitAll`, to be more explicit about authorization
* Require authentication to return error pages, along with a test to verify that an a unauthenticated client receives a 401